### PR TITLE
[WIP/UNTESTED] An untested attempt at adding the runtime versions into the graph

### DIFF
--- a/bench.plot
+++ b/bench.plot
@@ -17,5 +17,12 @@ set ylabel "seconds (lower is better)"
 set style fill transparent solid 0.25 # partial transparency
 set style fill noborder # no separate top/bottom lines
 
+# Shrink plot to allow space for version info below:
+set size 1.0, 0.8
+set origin 0,0.2
+
+# Output version info:
+set label sprintf("Runtime versions:\n%s", lang_versions) at -0.5,-1.8
+
 plot dat_name using 0:2:($2*($3/100.0)):xtic(2) with boxerrorbar lc "blue" notitle, \
   '' using 0:(max-(0.05*max)):1 with labels

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -7,6 +7,23 @@ result_dir="results"
 plot_script="bench.plot"
 : "${repeats:=5}"
 
+# Extract language versions:
+lang_versions=""
+is_first_lang="yes"
+for i in $(seq 0 ${#language[@]})
+do
+  version="unknown"
+  if [ -f "$test_dir/$1.version.txt" ]; then
+    version=`cat "$test_dir/$1.version.txt"`
+  fi
+  if [ "x$is_first_lang" = xyes ]; then
+    is_first_lang="no"
+  else
+    lang_versions="$lang_versions, "
+  fi
+  lang_versions="$lang_versions$1 $version"
+done
+
 run_perf() {
   perf stat -r"$repeats" "$1" "$test_dir/$3.$2" 2>&1 | grep "time elapsed" |
     sed 's/ *\([0-9]*\),\([0-9]*\) .* seconds time elapsed *( +- *\([0-9]*\),\([0-9]*\)% )/\1.\2 \3.\4/'
@@ -28,7 +45,7 @@ get_test() {
 }
 
 plot() {
-  gnuplot -e "$1" "$plot_script"
+  gnuplot -e "$1" -e "lang_versions='$lang_versions'" "$plot_script"
 }
 
 run_test() {


### PR DESCRIPTION
So this is super untested, but what about something like this?

I tested the plot layout, but I'm not sure how to test the actual data transfer from a perf run. This is how the plot layout looks like:
![binary-trees](https://user-images.githubusercontent.com/64124388/108216708-ad994400-712a-11eb-9ad9-c2b59d43844b.png)

(might require some more tweaks, like adding in "\n" after every 3 lang versions)

Anyway, maybe it might be worth trying to get this in and see if it runs at all if you can somehow test that? And then visual tweaks like line breaks, and actually providing the new files (`gwen.version.txt` etc) so something else than "unknown" shows up could be done later.