### PR TITLE
Link the latest results web page, capitalize "Gwion"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gwion-benchmark
+# gwion-benchmark
 
 Tools to run a benchmark of Gwion compared to other languages.
 Find the [latest results here](https://gwion.github.io/Gwion/Benchmarks.html).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# gwion-benchmark
-benchmark gwion against other languages
+# Gwion-benchmark
+
+Tools to run a benchmark of Gwion compared to other languages.
+Find the [latest results here](https://gwion.github.io/Gwion/Benchmarks.html).


### PR DESCRIPTION
Small tweaks to the README capitalizing Gwion (that seems to be the official spelling) and linking the results page so people don't need to go hunting for it when they get here via the repo