### PR TITLE
Checkout version.sh from the master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
         git config --local user.name "GitHub Action"
         git checkout origin/master benchmark.sh version.sh bench.plot src
         bash benchmark.sh
-        git rm -rf benchmark.sh bench.plot src
+        git rm -rf benchmark.sh version.sh bench.plot src
         echo "${{ github.event.client_payload.commit_info }}" > commit_info
         git add results png commit_info
         git commit -m "Add changes"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
         echo "info ${{ github.event.client_payload.commit_info }}"
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git checkout origin/master benchmark.sh bench.plot src
+        git checkout origin/master benchmark.sh version.sh bench.plot src
         bash benchmark.sh
         git rm -rf benchmark.sh bench.plot src
         echo "${{ github.event.client_payload.commit_info }}" > commit_info


### PR DESCRIPTION
# Summary
Currently the benchmark suite uses `version.sh` in the results branch rather than the one in the master branch. This PR changes this so the CI/CD process checks out `version.sh` from master and uses this instead.

~~**Note:** The `version.sh` in the results branch can be deleted - but isn't as part of this PR.~~ Nevermind, I see that the process cleans up these files.