### PR TITLE
Add Kuroko to benchmark suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,12 @@ jobs:
         ./pbuild/pbuild download
         ./pbuild/pbuild build --cc-type=gcc
         mv ~/PCrap/bin/pcrap .
+  
+    - name: Kuroko
+      run: |
+        git clone https://github.com/kuroko-lang/kuroko
+        cd kuroko
+        make kuroko
 
     - name: Benchmark
       run: |
@@ -131,6 +137,7 @@ jobs:
         export PATH=./Gwion:$PATH
         export PATH=./Dictu:$PATH
         export PATH=./snap/bin:$PATH
+        export PATH=./kuroko:$PATH
         export PATH=.:$PATH
         git checkout results
         git pull origin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
       run: |
         git clone https://github.com/kuroko-lang/kuroko
         cd kuroko
-        make kuroko
+        make
 
     - name: Benchmark
       run: |
@@ -145,7 +145,7 @@ jobs:
         echo "info ${{ github.event.client_payload.commit_info }}"
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git checkout origin/master benchmark.sh version.sh bench.plot src
+        git checkout ${GITHUB_REF} benchmark.sh version.sh bench.plot src
         bash benchmark.sh
         git rm -rf benchmark.sh version.sh bench.plot src
         echo "${{ github.event.client_payload.commit_info }}" > commit_info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: [benchmark-event]
 

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-language=("gwion" "wren" "lua" "python" "chuck" "ruby" "horse64" "dictu" "vyse" "pcrap")
-extension=("gw" "wren" "lua" "py" "ck" "rb" "h64" "du" "vy" "pc")
+language=("gwion" "wren" "lua" "python" "chuck" "ruby" "horse64" "dictu" "vyse" "pcrap" "kuroko")
+extension=("gw" "wren" "lua" "py" "ck" "rb" "h64" "du" "vy" "pc" "krk")
 test_dir="src"
 result_dir="results"
 plot_script="bench.plot"

--- a/src/binary-trees.krk
+++ b/src/binary-trees.krk
@@ -1,0 +1,41 @@
+# The Computer Language Benchmarks Game
+# http://shootout.alioth.debian.org/
+#
+# contributed by Antoine Pitrou
+# modified by Dominique Wahli
+# modified by Heinrich Acker
+# modified by Kay Lange
+
+import math
+
+def make_tree(item, depth):
+    if not depth: return item, None, None
+    let item2 = item + item
+    depth -= 1
+    return item, make_tree(item2 - 1, depth), make_tree(item2, depth)
+
+def check_tree(node):
+    let item, left, right
+    item, left, right = node
+    if not left: return item
+    return item + check_tree(left) - check_tree(right)
+
+let min_depth = 4
+let max_depth = 12
+let stretch_depth = max_depth + 1
+
+print("stretch tree of depth", stretch_depth, "check:", check_tree(make_tree(0, stretch_depth)))
+
+let long_lived_tree = make_tree(0, max_depth)
+
+let iterations = int(2.0 ** max_depth)
+for depth = min_depth; depth < stretch_depth; depth += 2:
+
+    let check = 0
+    for i in range(1, iterations + 1):
+        check += check_tree(make_tree(i, depth)) + check_tree(make_tree(-i, depth))
+
+    print(iterations * 2, "trees of depth", depth, "check:", check)
+    iterations = iterations // 4
+
+print("long lived tree of depth", max_depth, "check:", check_tree(long_lived_tree))

--- a/src/fib-recurs.krk
+++ b/src/fib-recurs.krk
@@ -1,0 +1,7 @@
+def fibonacci_recurs(n):
+  if n < 2:
+    return n
+  else:
+    return (fibonacci_recurs(n-1) + fibonacci_recurs(n-2))
+
+print(fibonacci_recurs(40))

--- a/src/fib.krk
+++ b/src/fib.krk
@@ -1,0 +1,6 @@
+def fib(n):
+  if n < 2: return n
+  return fib(n - 1) + fib(n - 2)
+
+for i in range(0, 5):
+  print(fib(28))

--- a/src/for.krk
+++ b/src/for.krk
@@ -1,0 +1,9 @@
+if True:
+  let l = []
+  for i in range(0, 1000000):
+    l.append(i)
+
+  let s = 0.0
+  for i in l:
+    s += i
+  print(s)

--- a/src/method-call.krk
+++ b/src/method-call.krk
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+# http://www.bagley.org/~doug/shootout/
+
+class Toggle(object):
+    def __init__(self, start_state):
+        self.bool = start_state
+    def value(self):
+        return(self.bool)
+    def activate(self):
+        self.bool = not self.bool
+        return(self)
+
+class NthToggle(Toggle):
+    def __init__(self, start_state, max_counter):
+        Toggle.__init__(self, start_state)
+        self.count_max = max_counter
+        self.counter = 0
+    def activate(self):
+        self.counter += 1
+        if (self.counter >= self.count_max):
+            super(NthToggle, self).activate()
+            self.counter = 0
+        return(self)
+
+
+def main():
+    let NUM = 100000
+
+    let val = 1
+    let toggle = Toggle(val)
+    for i in range(0,NUM):
+        val = toggle.activate().value()
+        val = toggle.activate().value()
+        val = toggle.activate().value()
+        val = toggle.activate().value()
+        val = toggle.activate().value()
+        val = toggle.activate().value()
+        val = toggle.activate().value()
+        val = toggle.activate().value()
+        val = toggle.activate().value()
+        val = toggle.activate().value()
+    if val:
+        print("true")
+    else:
+        print("false")
+
+    val = 1
+    let ntoggle = NthToggle(val, 3)
+    for i in range(0,NUM):
+        val = ntoggle.activate().value()
+        val = ntoggle.activate().value()
+        val = ntoggle.activate().value()
+        val = ntoggle.activate().value()
+        val = ntoggle.activate().value()
+        val = ntoggle.activate().value()
+        val = ntoggle.activate().value()
+        val = ntoggle.activate().value()
+        val = ntoggle.activate().value()
+        val = ntoggle.activate().value()
+    if val:
+        print("true")
+    else:
+        print("false")
+
+main()

--- a/src/string-equals.krk
+++ b/src/string-equals.krk
@@ -1,0 +1,28 @@
+let count = 0
+for i in range(0, 1000000):
+  if "abc" == "abc":
+    count = count + 1
+  if "a slightly longer string" == \
+     "a slightly longer string":
+      count = count + 1
+  if "a significantly longer string but still not overwhelmingly long string" == \
+     "a significantly longer string but still not overwhelmingly long string":
+      count = count + 1
+
+  if "" == "abc":
+    count = count + 1
+  if "abc" == "abcd":
+    count = count + 1
+  if "changed one character" == "changed !ne character":
+    count = count + 1
+  if "a slightly longer string" == \
+     "a slightly longer string!":
+      count = count + 1
+  if "a slightly longer string" == \
+     "a slightly longer strinh":
+      count = count + 1
+  if "a significantly longer string but still not overwhelmingly long string" == \
+     "another":
+      count = count + 1
+
+print(count)

--- a/version.sh
+++ b/version.sh
@@ -9,6 +9,7 @@ chuck: $(chuck --version 2>&1 | head -2 | tail -1 | cut -d " " -f 3-5)
 ruby: $(ruby -v | cut -d" " -f2)
 horse64: $(horse64 --short-version)
 dictu: $(dictu -v)
-vyse: latest 
+vyse: latest
 pcrap: latest
+kuroko: $(kuroko --version)
 EOF


### PR DESCRIPTION
Greetings,

I have added [Kuroko](https://kuroko-lang.github.io/) to the benchmark suite. Most of the tests are slight modifications of the equivalent Python versions. Kuroko performs roughly on-par with CPython and Horse64, beating those in the naïve Fibonacci calculation tests but not doing quite as well in some of the shorter tests.

Additionally, this MR includes two changes to the Github Actions workflow that helped me with debugging my fork:
- Add `workflow_dispatch` so that builds can be manually triggered from the Github web UI.
- Use `${GITHUB_REF}` when checking out the benchmark scripts so that the workflow can be run against other branches than `master`.