### PR TITLE
Adjust Horse64 location since it migrated to Codeberg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Horse64
       run: |
-        git clone https://github.com/horse64/old-core.horse64.org
+        git clone https://codeberg.org/Horse64/old-core.horse64.org
         cd old-core.horse64.org
         git submodule update --init
         make release


### PR DESCRIPTION
This change will ajust the old Horse64 archive location since due to the AI sloppification and [apparent non-consensual crawling of Microslop's Co-Pilot on Github repositories](https://archive.is/1EzVK/image) fueling the [observed rampant plagiarism](https://dl.acm.org/doi/10.1145/3543507.3583199), I'll soon delete the old copy of the Horse64 archive on Github. Stay in school, kids, and don't smoke gen AI.

*(Note on the future: the new version of Horse64 is still in development, but isn't ready for use yet. Once it is, I'll make another update to use the new version. I'm expecting it to be usable in about a year from now.)*